### PR TITLE
Drop release candidate heading

### DIFF
--- a/bylaws.md
+++ b/bylaws.md
@@ -1,4 +1,4 @@
-ΛΑΝ By-Laws Release Candidate
+ΛΑΝ By-Laws
 
 NOTES ON FORMATTING:
 For quality of diffs, please use one line per logical . terminated sentence.


### PR DESCRIPTION
Since this is the up to date copy of the bylaws, and the copy referred
to by lanbot, there's no reason to act like they're unofficial.
