### PR TITLE
Start adding more docs

### DIFF
--- a/pledges.md
+++ b/pledges.md
@@ -6,23 +6,75 @@ This document exists to serve as a record and reference of the ΛΑΝ pledge sel
  
 The semesterly rush process has traditionally opened with a week of open events, consisting of two or three information session presentations, and at least one coffee or pizza night.
 Exact details vary by semester.
-
 These events are open to the public, and are advertised for example on the UTCS Facebook group.
-No official attendance is taken at any of these events, and the goal of these events is to inform potential Candidates of the rush process mechanics.
-However potential Candidates are heavily encouraged to create and populate profiles on Omega.
-Actives are able to give feedback on Candidates via Omega at all times.
+
+At this point the term for non-members interested in joining is Applicant.
+
+No official attendance is taken at any of these events, and the goal of these events is to inform potential Applicants of the rush process mechanics.
+However potential Applicants are heavily encouraged to create and populate profiles on Omega.
+Actives are able to give feedback on Applicants via Omega at all times.
 
 This week of informational events concludes with an application due on Omega, usually that Sunday.
 After "first round" Candidate applications are closed, the Board of Officers meets to review applications.
 
 ### Applications
 
+The exact first round application varies year by year, but it is at a high level designed simply as an effort filter.
+The application typically consists of four or five questions which Candidates are welcome to answer at whatever length they feel is appropriate.
+Questions have included "why are you interested in ΛΑΝ", "why are you passionate about computing" and other questions designed to gauge interest in the Fraternity and the degree to which a Candidate shares our professional and social goals.
+
+In reviewing applications, the Board considers first any feedback which Actives left on Omega.
+The primary concern of the Board at this point is to filter out Candidates who have not demonstrated interest either by failing to attend events, or who have exhibited antisocial or concerning behavior either at a Fraternity event or in previous contact with Actives.
+Positive reviews of Applicants are of course welcome, however this application is designed to be a high pass filter designed to remove troll/not serious Applicants (we've actually had a few).
+
+The approximate review algorithm is as follows.
+
+- All feedback on a Candidate is read and discussed, then a proposal to accept, pass or reject the Candidate is made.
+- A vote is taken as to whether there is desire to pass the Candidate on to the next round.
+- If the Officers vote to accept a candidate, they are will be accepted and proceed to the next round of the pledge process.
+- If the vote is to pass, then the candidate is shelved to be reconsidered and the Board moves on for now.
+- This is typically used as a time saving measure so that contentious candidates can be considered at length after most decisions have already been made.
+- If the vote is to reject, then the candidate is removed from consideration and will not progress in the pledge process.
+
+According to the Bylaws, only a simple majority of Officers is required to accept or reject an Applicant.
+However by custom, this process of candidate consideration continues until there is a consensus on each individual Applicant.
+
+The term for an Applicant who has been accepted is Candidate.
+
+Once all Applicants have either been accepted or rejected, official emails are respectively thanking rejected Applicants for their time and inviting them to try again next semester, or inviting the accepted Candidates to the Second Round events.
+
 ## Second Round
+
+The second round consists of usually two private, invitation only events designed to give Active members an opportunity to meet and have meaningful interactions with the Candidates before they are considered for Pledge status.
+In past semesters we've done cookouts, distributed events and in the first semester a pool party for this phase.
+
+As with the First Round, Actives are able to submit feedback on Candidates via Omega.
+This feedback will be considered together with Interview results when deciding Bids.
 
 ### Interviews
 
+The second round concludes with Interviews.
+Interviews are conducted two or three Officers to one Candidate, and consist of questions designed to gauge the extent to which a Candidate socialized with their fellow Candidates and collect some basic information required for various organizational tasks.
+
 ## Bids
 
-## Bigs
+Bids are decided using the same process as Applications are reviewed.
+Member feedback is the dominating concern, with personal interactions with Candidates and interview results considered.
 
-## Induction
+The technical term for someone accepted by a Bid decision is Associate Member, or colloquially a Pledge.
+
+Once the accept/reject lists are finalized, notification emails are again sent. Pledges are invited to Bid Day, and rejected Candidates are thanked for their time, informed of the stiff competition and invited to try again next semester.
+
+### Bid Day
+
+Bid day marks several important events:
+
+1. Pledges get Slack access
+2. Pledges are informed of the Code of Conduct and Standards Board
+2. Pledges sign Membership Agreements, being contracts to pay dues, uphold the Code of Conduct and abide by the decisions of the Standards Board
+
+### Pledge Class President
+
+### Bigs
+
+### Induction

--- a/pledges.md
+++ b/pledges.md
@@ -1,0 +1,28 @@
+# ΛΑΝ Pledge Process
+
+This document exists to serve as a record and reference of the ΛΑΝ pledge selection and induction process for existing and prospective members.
+ 
+## First Round
+ 
+The semesterly rush process has traditionally opened with a week of open events, consisting of two or three information session presentations, and at least one coffee or pizza night.
+Exact details vary by semester.
+
+These events are open to the public, and are advertised for example on the UTCS Facebook group.
+No official attendance is taken at any of these events, and the goal of these events is to inform potential Candidates of the rush process mechanics.
+However potential Candidates are heavily encouraged to create and populate profiles on Omega.
+Actives are able to give feedback on Candidates via Omega at all times.
+
+This week of informational events concludes with an application due on Omega, usually that Sunday.
+After "first round" Candidate applications are closed, the Board of Officers meets to review applications.
+
+### Applications
+
+## Second Round
+
+### Interviews
+
+## Bids
+
+## Bigs
+
+## Induction


### PR DESCRIPTION
In response to Sarah's well grounded concerns that we don't have much of our processes written down, this changeset will track adding organizational process documentation appropriate to general publication to the docs repo.
- [ ] Pledge process
- [ ] Guest rules
- [ ] Code of Conduct
- [ ] Membership Agreement
- [ ] Historical calendar?
- [ ] List of members by class?
- [ ] List of officers and positions by year?
- [ ] Voting process FAQ

Obviously internal/secret rituals and history stuff won't be covered here, goal is to provide detailed FAQ style references for existing and prospective members.
