### PR TITLE
Added purchase proposal documentation

### DIFF
--- a/purchasing.md
+++ b/purchasing.md
@@ -1,0 +1,24 @@
+# Purchase Proposal Process
+
+### Purpose
+Purchase proposals are intended for large purchases that do not fall under a budget line item. As a loose policy, purchases under $50 do not need to go through this formal proposal process. Instead, talk directly to the Treasurer.
+
+### Process
+The purchase proposal process is designed to facilitate discussion regarding large purchases using money saved during past semesters. As such, the process is relatively lengthy and requires several groups to be informed of the proposal.
+
+* Active member (sponsor) and co-sponsor make a copy of the [Purchase Proposal Form](https://docs.google.com/document/d/1NLBVKC-qtxbgqiNM-yJDcRpZsLDAnCEaChASRXLSzP8/edit?usp=sharing) and fills out the appropriate sections (down to **Follow up date**).
+* Sponsor presents complete proposal form to Treasurer for approval.
+    * If the proposal is rejected, the Treasurer will inform the sponsor of adjustments to be made. The proposal can be resubmitted to the Treasurer once corrected.
+    * If the proposal is approved, the process will continue as described below.
+* The Treasurer will present the purchase proposal to the Board at an officer meeting.
+    * The Board can veto the purchase proposal by a ⅔’rds vote. If vetoed, the proposal must be recreated and must go through the entire purchase proposal process again.
+    * If the proposal is not vetoed, the process will continue as described below.
+* The Treasurer will briefly present the purchase proposal at a general meeting.
+    * The general membership may initiate the veto process by support of three active members.
+    * The general membership may veto the purchase proposal by a simple majority of those present. If vetoed, the proposal must be recreated and must go through the entire purchase proposal process again.
+* The purchase proposal is executed as described in the proposal form.
+* The Treasurer will follow up with the purchase to ensure it is properly and fully executed.
+* If the purchase is not properly executed as described in the purchase proposal, the Treasurer will take steps to correct the situation (including, but not limited to, cancellation of the purchase proposal).
+
+### Other Notes
+ * All purchase proposals will be archived by the Treasurer and will be made available upon request.


### PR DESCRIPTION
As discussed in the September 5th officer meeting, this document outlines the procedure for proposing large one time purchases to the Treasurer, with oversight from the Board and General Membership.
